### PR TITLE
Update exit() to exitApp()

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -40,7 +40,7 @@
    *   var currentPlatform = ionic.Platform.platform();
    *   var currentPlatformVersion = ionic.Platform.version();
    *
-   *   ionic.Platform.exit(); // stops the app
+   *   ionic.Platform.exitApp(); // stops the app
    * });
    * ```
    */


### PR DESCRIPTION
Updated exit() to exitApp() for documentation as the name of the function is exitApp.